### PR TITLE
Hide discv5 draft reports

### DIFF
--- a/content.en/ethereum/discv5/2024-02-report.md
+++ b/content.en/ethereum/discv5/2024-02-report.md
@@ -2,6 +2,7 @@
 title: Week 2024-02
 plotly: true
 weight: 1048573
+bookHidden: true
 slug: 2024-02
 aliases:
     - /discv5/2024-02/

--- a/content.en/ethereum/discv5/2024-09-report.md
+++ b/content.en/ethereum/discv5/2024-09-report.md
@@ -2,6 +2,7 @@
 title: Week 2024-09
 plotly: true
 weight: 1048566
+bookHidden: true
 slug: 2024-09
 aliases:
     - /discv5/2024-09/


### PR DESCRIPTION
Reports `2024-02` and `2024-09` were WIP to show ongoing work. Now that we have final reports, we don't need them anymore. Let's hide them!