### PR TITLE
add first draft of Hermes documentation

### DIFF
--- a/content.en/tools/_index.md
+++ b/content.en/tools/_index.md
@@ -1,7 +1,7 @@
 ---
 title: Tools & Data
 bookCollapseSection: true
-weight: 50
+weight: 60
 ---
 
 # Tools
@@ -25,6 +25,7 @@ ProbeLab is running multiple sets of experiments that aim to push the boundaries
 ProbeLab has built a website performance measurement tool, called [`tiros`](https://github.com/probe-lab/tiros) for websites hosted on IPFS. Tiros is designed to help developers monitor and optimize the performance of their IPFS-hosted websites. `Tiros`-based experiments measure retrieval and rendering metrics of websites loaded over IPFS. It also measures and compares the IPFS metrics with their HTTPS counterparts.
 
 {{< button relref="/tiros" >}}Learn more{{< /button >}}
+
 
 ## Hermes
 

--- a/content.en/tools/_index.md
+++ b/content.en/tools/_index.md
@@ -28,7 +28,7 @@ ProbeLab has built a website performance measurement tool, called [`tiros`](http
 
 ## Hermes
 
-[Hermes](https://github.com/probe-lab/hermes) is a [GossipSub](https://docs.libp2p.io/concepts/pubsub/overview/) listener and tracer for [Libp2p](https://libp2p.io/)-based networks. `Hermes`-base experiments aim to measure the efficiency and performance of the GossipSub message broadcasting protocol in any `libp2p`-based networks, helping developers to tune their network's protocols based on the message propagation latency and control messages' overhead. `Hermes` currently supports `Ethereum CL`-based networks.  
+[Hermes](https://github.com/probe-lab/hermes) is a [GossipSub](https://docs.libp2p.io/concepts/pubsub/overview/) listener and tracer for [libp2p](https://libp2p.io/)-based networks. `Hermes`-based experiments aim to measure the efficiency and performance of the GossipSub message broadcasting protocol in any `libp2p`-based network. `Hermes` can help developers tune their network's protocols based on the message propagation latency and control message overhead. `Hermes` currently supports `Ethereum CL`-based networks.  
 
 {{< button relref="/hermes" >}}Learn more{{< /button >}}
 

--- a/content.en/tools/_index.md
+++ b/content.en/tools/_index.md
@@ -26,6 +26,12 @@ ProbeLab has built a website performance measurement tool, called [`tiros`](http
 
 {{< button relref="/tiros" >}}Learn more{{< /button >}}
 
+## Hermes
+
+[Hermes](https://github.com/probe-lab/hermes) is a [GossipSub](https://docs.libp2p.io/concepts/pubsub/overview/) listener and tracer for [Libp2p](https://libp2p.io/)-based networks. `Hermes`-base experiments aim to measure the efficiency and performance of the GossipSub message broadcasting protocol in any `libp2p`-based networks, helping developers to tune their network's protocols based on the message propagation latency and control messages' overhead. `Hermes` currently supports `Ethereum CL`-based networks.  
+
+{{< button relref="/hermes" >}}Learn more{{< /button >}}
+
 ## Data Provenance
 
 The data produced by the tools above is used to generate the majority of plots on this website. Some external sources of data such as metrics produced by 

--- a/content.en/tools/data.md
+++ b/content.en/tools/data.md
@@ -1,6 +1,8 @@
 ---
 title: Data Provenance
+weight: 50
 ---
+
 # Data Provenance
 
 The majority of the data used to generate the plots and charts on this site originates from the experiments run by 

--- a/content.en/tools/hermes.md
+++ b/content.en/tools/hermes.md
@@ -1,24 +1,24 @@
 # Hermes
-Hermes is a light-node for [libp2p](https://libp2p.io/)-based networks that monitors the effectiveness and performance of the [GossipSub](https://docs.libp2p.io/concepts/pubsub/overview/) message propagation protocol. The tool behaves like a light-node in the network, connecting to other participants in the network, relying on a trusted local node that ensures we can reply any incoming request to maintain stable connections. The tool currently supports any [Ethereum](https://ethereum.org/en/) network (the `Consensus Layer`), although there might me more networks coming in the future.
+Hermes is a light-node for [libp2p](https://libp2p.io/)-based networks that can be used to monitor the effectiveness and performance of the [GossipSub](https://docs.libp2p.io/concepts/pubsub/overview/) message propagation protocol. The tool behaves like a light-node in the network, connecting to other participants in the network, relying on a trusted local node that ensures we can reply to any incoming request and maintain stable connections. The tool currently supports any [Ethereum](https://ethereum.org/en/) network (at the `Consensus Layer`), although there might me more networks coming in the future.
 
 {{< button href="https://github.com/probe-lab/hermes" >}}GitHub{{< /button >}}
 
 ## Components
-Hermes a single component, the **light-node** for each network. However, it has two major requirements to work: 1) a **trusted local node** that will provide the right view of the chain's state and 2) an **event consumer** that will receive all the libp2p traces and will store them. The light-node is responsible for discovering peers, maintain the connection with them, and to monitor the internal events at the libp2p host.
+Hermes operates as a single component, the **light-node**, for each network it is deployed in. However, it has two major requirements to work: 1) a **trusted local node** that will provide the right view of the chain's state and 2) an **event consumer** that will receive all the libp2p traces and will store them. The light-node is responsible for discovering peers, maintain connections with them, and monitor the internal events at the libp2p host.
 
 ## How does it work?
 
 ### Light-node
-Hermes operates like a standard Libp2p node, discovering and connecting to the network while supporting all Libp2p protocols to ensure reliable and secure communication. It connects to a trusted local or remote node for certain RPCs that require chain state information, leveraging these trusted sources to enhance its capabilities.
+Hermes operates like a standard libp2p node, discovering and connecting to the network while supporting all libp2p protocols to ensure reliable and secure communication. It connects to a trusted local, or remote node for certain RPCs that require chain state information, leveraging these trusted sources to enhance its capabilities.
 
-It subscribes to all available GossipSub topics, allowing it to comprehensively receive, unveil and trace all the interactions with the network. This enables it to keep track of network activity efficiently.
+Hermes subscribes to all available GossipSub topics, allowing it to comprehensively receive, unveil and trace all the interactions with the network. This enables the tool to keep track of network activity efficiently.
 
 Additionally, Hermes can submit these traces to any defined consumer, with current support for [AWS Kinesis](https://aws.amazon.com/kinesis/) and [Xatu](https://github.com/ethpandaops/xatu) from the Ethereum Foundation (EF). This feature facilitates the integration of network data with analytics and monitoring tools, aiding in the overall security and functionality of the network.
 
 ## What data does Hermes gather?
-As `Hermes` maintains stable connections with the rest of the network nodes, it can emit debugging traces of how Libp2p and GossipSub work in the "wild". 
+As `Hermes` maintains stable connections with the rest of the network nodes, it can emit debugging traces of how libp2p and GossipSub work in the wild. 
 
-To summarize, `Hermes` gathers the following information from the Libp2p host and the GossipSub protocol:
+`Hermes` gathers the following information from the libp2p host and the GossipSub protocol:
 
 - Connections and Disconnections from the libp2p host
 
@@ -26,18 +26,18 @@ To summarize, `Hermes` gathers the following information from the Libp2p host an
 
     - Subscriptions from other nodes to topics
 
-    - Graft and Prunes
+    - GRAFT and PRUNE control messages
 
-    - Gossips peerscores 
+    - GossipSub peer scores 
 
-    - IHaves and IWant messages
+    - IHAVE and IWANT control messages
 
 - Sent and received messages
 
 - Protoco RPCs
 
 ## Deployment
-`Hermes` has been developed with the intion of leving it running for an indefinite time duration. If you are interested in the data from other networks, reach out to us through any of the channels listed at the [Contact](/about/#contact) page.
+`Hermes` has been developed with the intention of leaving it running for an indefinite time duration. If you are interested in the data from other networks, reach out to us through any of the channels listed at the [Contact](/about/#contact) page.
 
 ## Contributing
 Feel free to head over to the GitHub repository and dive in! [Open an issue](https://github.com/probe-lab/hermes) or submit PRs.

--- a/content.en/tools/hermes.md
+++ b/content.en/tools/hermes.md
@@ -1,0 +1,45 @@
+# Hermes
+Hermes is a light-node for [libp2p](https://libp2p.io/)-based networks that monitors the effectiveness and performance of the [GossipSub](https://docs.libp2p.io/concepts/pubsub/overview/) message propagation protocol. The tool behaves like a light-node in the network, connecting to other participants in the network, relying on a trusted local node that ensures we can reply any incoming request to maintain stable connections. The tool currently supports any [Ethereum](https://ethereum.org/en/) network (the `Consensus Layer`), although there might me more networks coming in the future.
+
+{{< button href="https://github.com/probe-lab/hermes" >}}GitHub{{< /button >}}
+
+## Components
+Hermes a single component, the **light-node** for each network. However, it has two major requirements to work: 1) a **trusted local node** that will provide the right view of the chain's state and 2) an **event consumer** that will receive all the libp2p traces and will store them. The light-node is responsible for discovering peers, maintain the connection with them, and to monitor the internal events at the libp2p host.
+
+## How does it work?
+
+### Light-node
+Hermes operates like a standard Libp2p node, discovering and connecting to the network while supporting all Libp2p protocols to ensure reliable and secure communication. It connects to a trusted local or remote node for certain RPCs that require chain state information, leveraging these trusted sources to enhance its capabilities.
+
+It subscribes to all available GossipSub topics, allowing it to comprehensively receive, unveil and trace all the interactions with the network. This enables it to keep track of network activity efficiently.
+
+Additionally, Hermes can submit these traces to any defined consumer, with current support for [AWS Kinesis](https://aws.amazon.com/kinesis/) and [Xatu](https://github.com/ethpandaops/xatu) from the Ethereum Foundation (EF). This feature facilitates the integration of network data with analytics and monitoring tools, aiding in the overall security and functionality of the network.
+
+## What data does Hermes gather?
+As `Hermes` maintains stable connections with the rest of the network nodes, it can emit debugging traces of how Libp2p and GossipSub work in the "wild". 
+
+To summarize, `Hermes` gathers the following information from the Libp2p host and the GossipSub protocol:
+
+- Connections and Disconnections from the libp2p host
+
+- Control GossipSub messages:
+
+    - Subscriptions from other nodes to topics
+
+    - Graft and Prunes
+
+    - Gossips peerscores 
+
+    - IHaves and IWant messages
+
+- Sent and received messages
+
+- Protoco RPCs
+
+## Deployment
+`Hermes` has been developed with the intion of leving it running for an indefinite time duration. If you are interested in the data from other networks, reach out to us through any of the channels listed at the [Contact](/about/#contact) page.
+
+## Contributing
+Feel free to head over to the GitHub repository and dive in! [Open an issue](https://github.com/probe-lab/hermes) or submit PRs.
+
+{{< button href="https://github.com/probe-lab/hermes" >}}GitHub{{< /button >}}

--- a/content.en/tools/hermes.md
+++ b/content.en/tools/hermes.md
@@ -1,4 +1,10 @@
+---
+title: Hermes
+weight: 40
+---
+
 # Hermes
+
 Hermes is a light-node for [libp2p](https://libp2p.io/)-based networks that can be used to monitor the effectiveness and performance of the [GossipSub](https://docs.libp2p.io/concepts/pubsub/overview/) message propagation protocol. The tool behaves like a light-node in the network, connecting to other participants in the network, relying on a trusted local node that ensures we can reply to any incoming request and maintain stable connections. The tool currently supports any [Ethereum](https://ethereum.org/en/) network (at the `Consensus Layer`), although there might me more networks coming in the future.
 
 {{< button href="https://github.com/probe-lab/hermes" >}}GitHub{{< /button >}}

--- a/content.en/tools/nebula/_index.md
+++ b/content.en/tools/nebula/_index.md
@@ -1,3 +1,8 @@
+---
+title: Nebula
+weight: 10
+---
+
 ![Nebula Logo](./nebula.png)
 
 # Nebula

--- a/content.en/tools/parsec.md
+++ b/content.en/tools/parsec.md
@@ -1,3 +1,8 @@
+---
+title: Parsec
+weight: 20
+---
+
 # Parsec
 
 `parsec` is a Distributed Hash Table (DHT) and InterPlanetary Network Intexer ([IPNI](https://github.com/ipni)) lookup performance measurement tool. It specifically measures the `PUT` and `GET` performance of the **IPFS** public DHT but could also be configured to measure other [libp2p-kad-dht](https://github.com/libp2p/specs/blob/master/kad-dht/README.md) networks. The setup is split into two components 1) a **scheduler** and 2) a **server**.

--- a/content.en/tools/tiros.md
+++ b/content.en/tools/tiros.md
@@ -1,3 +1,8 @@
+---
+title: Tiros
+weight: 30
+---
+
 # Tiros
 
 Tiros is a performance measurement tool for IPFS-hosted websites. It orchestrates the interplay between


### PR DESCRIPTION
# Description 
Following @yiannisbot 's suggestion un #119, this PR adds [`Hermes`](https://github.com/probe-lab/hermes) to the list of tooling that we have at ProbeLab, together with a small description page with more details. 
