### PR TITLE
chore: hide Goldberg reports

### DIFF
--- a/content.en/avail/dht/2024-10-report.md
+++ b/content.en/avail/dht/2024-10-report.md
@@ -3,6 +3,7 @@ title: Week 2024-10
 plotly: true
 slug: 2024-10
 weight: 1045649
+bookHidden: true
 ---
 
 # Avail Report Cal. Week 10 - 2024

--- a/content.en/avail/dht/2024-11-report.md
+++ b/content.en/avail/dht/2024-11-report.md
@@ -3,6 +3,7 @@ title: Week 2024-11
 plotly: true
 slug: 2024-11
 weight: 1045648
+bookHidden: true
 ---
 
 # Avail Report Cal. Week 11 - 2024

--- a/content.en/avail/dht/2024-12-report.md
+++ b/content.en/avail/dht/2024-12-report.md
@@ -3,6 +3,7 @@ title: Week 2024-12
 plotly: true
 slug: 2024-12
 weight: 1045647
+bookHidden: true
 ---
 
 # Avail Report Cal. Week 12 - 2024

--- a/content.en/avail/dht/2024-13-report.md
+++ b/content.en/avail/dht/2024-13-report.md
@@ -3,6 +3,7 @@ title: Week 2024-13
 plotly: true
 slug: 2024-13
 weight: 1045646
+bookHidden: true
 ---
 
 # Avail Report Cal. Week 13 - 2024

--- a/content.en/avail/dht/2024-14-report.md
+++ b/content.en/avail/dht/2024-14-report.md
@@ -3,6 +3,7 @@ title: Week 2024-14
 plotly: true
 slug: 2024-14
 weight: 1045645
+bookHidden: true
 ---
 
 # Avail Report Cal. Week 14 - 2024

--- a/content.en/avail/dht/2024-15-report.md
+++ b/content.en/avail/dht/2024-15-report.md
@@ -3,6 +3,7 @@ title: Week 2024-15
 plotly: true
 slug: 2024-15
 weight: 1045644
+bookHidden: true
 ---
 
 # Avail Report Cal. Week 15 - 2024

--- a/content.en/avail/dht/2024-16-report.md
+++ b/content.en/avail/dht/2024-16-report.md
@@ -3,6 +3,7 @@ title: Week 2024-16
 plotly: true
 slug: 2024-16
 weight: 1045643
+bookHidden: true
 ---
 
 # Avail Report Cal. Week 16 - 2024

--- a/content.en/avail/dht/2024-17-report.md
+++ b/content.en/avail/dht/2024-17-report.md
@@ -3,6 +3,7 @@ title: Week 2024-17
 plotly: true
 slug: 2024-17
 weight: 1045642
+bookHidden: true
 ---
 
 # Avail Report Cal. Week 17 - 2024

--- a/content.en/avail/dht/2024-18-report.md
+++ b/content.en/avail/dht/2024-18-report.md
@@ -3,6 +3,7 @@ title: Week 2024-18
 plotly: true
 slug: 2024-18
 weight: 1045641
+bookHidden: true
 ---
 
 # Avail Report Cal. Week 18 - 2024

--- a/content.en/avail/dht/2024-19-report.md
+++ b/content.en/avail/dht/2024-19-report.md
@@ -3,6 +3,7 @@ title: Week 2024-19
 plotly: true
 slug: 2024-19
 weight: 1045640
+bookHidden: true
 ---
 
 # Avail Report Cal. Week 19 - 2024

--- a/content.en/avail/dht/2024-20-report.md
+++ b/content.en/avail/dht/2024-20-report.md
@@ -3,6 +3,7 @@ title: Week 2024-20
 plotly: true
 slug: 2024-20
 weight: 1045639
+bookHidden: true
 ---
 
 # Avail Report Cal. Week 20 - 2024

--- a/content.en/avail/dht/2024-21-report.md
+++ b/content.en/avail/dht/2024-21-report.md
@@ -3,6 +3,7 @@ title: Week 2024-21
 plotly: true
 slug: 2024-21
 weight: 1045638
+bookHidden: true
 ---
 
 # Avail Report Cal. Week 21 - 2024

--- a/content.en/avail/dht/2024-22-report.md
+++ b/content.en/avail/dht/2024-22-report.md
@@ -3,6 +3,7 @@ title: Week 2024-22
 plotly: true
 slug: 2024-22
 weight: 1045637
+bookHidden: true
 ---
 
 # Avail Report Cal. Week 22 - 2024

--- a/content.en/avail/dht/2024-23-report.md
+++ b/content.en/avail/dht/2024-23-report.md
@@ -3,6 +3,7 @@ title: Week 2024-23
 plotly: true
 slug: 2024-23
 weight: 1045636
+bookHidden: true
 ---
 
 # Avail Report Cal. Week 23 - 2024

--- a/content.en/avail/dht/2024-24-report.md
+++ b/content.en/avail/dht/2024-24-report.md
@@ -3,6 +3,7 @@ title: Week 2024-24
 plotly: true
 slug: 2024-24
 weight: 1045635
+bookHidden: true
 ---
 
 # Avail Report Cal. Week 24 - 2024

--- a/content.en/avail/dht/2024-25-report.md
+++ b/content.en/avail/dht/2024-25-report.md
@@ -3,6 +3,7 @@ title: Week 2024-25
 plotly: true
 slug: 2024-25
 weight: 1045634
+bookHidden: true
 ---
 
 # Avail Report Cal. Week 25 - 2024

--- a/content.en/avail/dht/2024-26-report.md
+++ b/content.en/avail/dht/2024-26-report.md
@@ -3,6 +3,7 @@ title: Week 2024-26
 plotly: true
 slug: 2024-26
 weight: 1045633
+bookHidden: true
 ---
 
 # Avail Report Cal. Week 26 - 2024

--- a/content.en/avail/dht/2024-27-report.md
+++ b/content.en/avail/dht/2024-27-report.md
@@ -3,6 +3,7 @@ title: Week 2024-27
 plotly: true
 slug: 2024-27
 weight: 1045632
+bookHidden: true
 ---
 
 # Avail Report Cal. Week 27 - 2024

--- a/content.en/avail/dht/2024-28-report.md
+++ b/content.en/avail/dht/2024-28-report.md
@@ -3,6 +3,7 @@ title: Week 2024-28
 plotly: true
 slug: 2024-28
 weight: 1045631
+bookHidden: true
 ---
 
 # Avail Report Cal. Week 28 - 2024

--- a/content.en/avail/dht/2024-29-report.md
+++ b/content.en/avail/dht/2024-29-report.md
@@ -3,6 +3,7 @@ title: Week 2024-29
 plotly: true
 slug: 2024-29
 weight: 1045630
+bookHidden: true
 ---
 
 # Avail Report Cal. Week 29 - 2024

--- a/content.en/avail/dht/2024-30-report.md
+++ b/content.en/avail/dht/2024-30-report.md
@@ -3,6 +3,7 @@ title: Week 2024-30
 plotly: true
 slug: 2024-30
 weight: 1045629
+bookHidden: true
 ---
 
 # Avail Report Cal. Week 30 - 2024


### PR DESCRIPTION
This PR hides the Goldberg reports from the website while still maintaining the page.