### PR TITLE
Delete wss support message as not valid anymore

### DIFF
--- a/content.en/celestia/dht/2025-05-report.md
+++ b/content.en/celestia/dht/2025-05-report.md
@@ -45,8 +45,6 @@ This stacked chart illustrates how the distribution of DHT servers agent version
 
 ## Lightnode Population
 
-> ⚠️ Our [DHT Client monitoring tool](https://github.com/probe-lab/ants-watch) doesn't support Secure WebSocket (`wss`) yet, so browser nodes aren't included in the measurements yet.
-
 This chart shows the distribution of all agents interacting with the DHT (both DHT clients and DHT servers) over time, including the Lightnode population.
 
 > 💡 To show the Lightnode population only, double-click on the `celestia-node/light` label.


### PR DESCRIPTION
`wss` support exists in `ants` since Week 2, 2025, hence, the message at the top of the LN Uptime Monitoring section does not need to be there anymore.